### PR TITLE
Automatic rollback from bad deploys

### DIFF
--- a/packages/rass-cli/example_projects/generic_x86/flake.nix
+++ b/packages/rass-cli/example_projects/generic_x86/flake.nix
@@ -6,18 +6,13 @@
   };
   outputs = { self, nixpkgs, ... }:
   {
-    ros_assistant = {
-      # The device the unattended installation ISO will install the OS to.
-      # You can leave this unspecified if you do not intend to do unattended installations.
-      generic-x86.target_device = "/dev/sda";
-    };
-
     nixosConfigurations.generic-x86 = nixpkgs.lib.nixosSystem {  
       system = "x86_64-linux";
       modules = [
         ../../nix_modules/basic_boot.nix
 	../../nix_modules/installer_iso.nix
 	../../nix_modules/installer_netboot.nix
+	../../nix_modules/auto_revert.nix
         ({ pkgs, lib, config, ...}: {
           system.stateVersion = "25.05";
 

--- a/packages/rass-cli/nix_modules/auto_revert.nix
+++ b/packages/rass-cli/nix_modules/auto_revert.nix
@@ -1,0 +1,52 @@
+# Provides a service that will automatically revert to a previous derivation
+# if rass fails to cancel the reversion in time. This is meant to be a convenient
+# recovery tool if you accidentally update the configuration in a way that locks
+# you out of your robot.
+{ config, pkgs ? import <nixpkgs> {}, lib, ... }:
+let
+  cfg = config.auto-revert;
+in
+{
+  options.auto-revert = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable auto-revert";
+    };
+    time = lib.mkOption {
+      type = lib.types.int;
+      default = 10;
+      description = "Number of seconds before auto-revert is performed";
+    };
+  };
+
+  config = {
+    systemd.services.auto-revert = {
+      enable = cfg.enable;
+      description = "Auto revert on update failure";
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        #!${pkgs.bash}/bin/bash -e
+        if [ -f '/run/rass/auto-revert/set' ]; then
+          echo "Auto revert timer set to ${toString cfg.time} second and started."
+          ${pkgs.coreutils}/bin/sleep ${toString cfg.time}
+        
+          if [ -f '/run/rass/auto-revert/set' ]; then
+            echo "Timer has expired. Reverting to previous generation."
+	    cd /tmp
+	    rm -f result
+            ${pkgs.nixos-rebuild}/bin/nixos-rebuild \
+              -I nixpkgs=/root/.nix-defexpr/channels \
+              test --rollback --verbose --fast
+            echo "System generation reverted"
+            rm -f '/run/rass/auto-revert/set'
+          else
+            echo "Auto revert aborted."
+          fi
+        else
+          echo "Auto-revert has not been enabled for this activation."
+        fi
+      '';
+    };
+  };
+}

--- a/packages/rass-cli/src/arguments.rs
+++ b/packages/rass-cli/src/arguments.rs
@@ -62,6 +62,11 @@ pub struct SshDeploy {
     /// makes the configuration the new boot default
     pub switch: bool,
 
+    /// do not trigger the auto-revert timer (this has a risk of locking you out of your robot if
+    /// things go wrong)
+    #[argh(switch)]
+    pub no_auto_revert: bool,
+
     #[argh(option)]
     /// override the default ssh destination (only works if deploying to a single host)
     pub destination: Option<String>,

--- a/packages/rass-cli/src/deploy.rs
+++ b/packages/rass-cli/src/deploy.rs
@@ -64,7 +64,8 @@ async fn deploy_ssh<'a>(
             context.deploy_ssh(
                 host,
                 &hostname,
-                args.switch
+                args.switch,
+                !args.no_auto_revert
             ).await
         },
     ).await?;
@@ -174,8 +175,6 @@ async fn install_netboot<'a>(
                     .context("Failed to canonicalize path to PXE boot dependencies")?;
 
                 let mut command = Command::new("sudo");
-
-// sudo pixiecore boot /nix/store/5dj4xbjgmq1kz3ny2dlmvzpmvdx84zbc-linux-6.12.38/bzImage /nix/store/yiiw7llmb3hc3s04rs63kbbh0iz4ikgx-initrd/initrd --cmdline "init=/nix/store/1sw1g2c753wkqmqnsgn8c7vkgj5mw28h-nixos-system-nixos-kexec-25.11pre-git/init loglevel=4" --port 64172 --status-port 64172
 
                 let kernel = output_directory.join("kernel/bzImage").canonicalize().context("Failed to canonacalize kernel path.")?;
                 let initrd = output_directory.join("netbootRamdisk/initrd").canonicalize().context("Failed to canonicalize initrd path")?;


### PR DESCRIPTION
Auto-revert is a safety net.
After completing a deployment, a timer will start. rass-cli needs to log in via ssh and cancel the timer. If it fails to do so, the system will be reverted to the previous configuration when the timer expires.

This is done to verify that your new configuration has not locked you out of your robot.

It only works if you include the `auto_revert.nix` module into your system configuration.
Unfortunately, I do not have a way for rass to warn you that you've forgotten to include it at this time.

