### PR TITLE
Auto revert now advises you to set it up when not present

### DIFF
--- a/packages/rass-cli/nix_modules/auto_revert.nix
+++ b/packages/rass-cli/nix_modules/auto_revert.nix
@@ -8,7 +8,7 @@ let
 in
 {
   options.auto-revert = {
-    enable = lib.mkOption {
+    enabled = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Enable auto-revert";


### PR DESCRIPTION
Currently, auto revert works, but only if you include the [auto revert module](https://github.com/IamTheCarl/ros_assistant/blob/1b3d6d981bc5a5deb99032bc54aae21a8dbddc70/packages/rass-cli/nix_modules/auto_revert.nix) in your system configuration. It will otherwise silently fail.

This PR adds the ability for rass-cli to detect that said module is present and enabled. It will refuse to deploy if it is not present and enabled, unless you pass the `--no-auto-revert` flag.